### PR TITLE
fix #11: metadata eliminada de readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,11 +1,3 @@
----
-title: Kuantifica
-description: Perfil público de la organización en GitHub
-created_on: 2026-04-19
-last_updated: 2026-04-19
-status: draft
----
-
 # Kuantifica
 
 > *Datos que mueven negocios reales.*


### PR DESCRIPTION
Se eliminó la metadata del README de perfil de Kuantifica.

Closes #11 